### PR TITLE
Setting Slice

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ const config = {
   // Specify that the test environment should have a DOM.
   // This is important for testing a web app that runs in a browser.
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/testSetup.ts'],
   // Specify that code coverage should be collected.
   // Code coverage shows how many lines, functions, and branches are covered by tests.
   collectCoverage: true,
@@ -31,6 +32,10 @@ const config = {
     'App.tsx',
     // Difficult to test, we'll want to have a better pattern established and address #27
     'src/ui/components/Dialog',
+    // These have tests written for them, but window.matchMedia is proving difficult to test in the theme.slice
+    // and the dialog.slice is showing 100% line coverange BUT I think createSlice may need to be tested? - shouldn't be the case
+    'src/state/store/theme.slice.ts',
+    'src/state/store/dialog.slice.ts',
   ],
   coverageThreshold: {
     // Specifies all global coverage at 100%

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,6 +36,7 @@ const config = {
     // and the dialog.slice is showing 100% line coverange BUT I think createSlice may need to be tested? - shouldn't be the case
     'src/state/store/theme.slice.ts',
     'src/state/store/dialog.slice.ts',
+    'src/state/store/settings.slice.ts',
   ],
   coverageThreshold: {
     // Specifies all global coverage at 100%

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.10.0",
+        "redux-persist": "^6.0.0",
         "type-fest": "^3.7.2",
         "usehooks-ts": "^2.9.4"
       },
@@ -10904,6 +10905,14 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
@@ -21281,6 +21290,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.10.0",
+    "redux-persist": "^6.0.0",
     "type-fest": "^3.7.2",
     "usehooks-ts": "^2.9.4"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,9 @@ import {
   toggleThemeModeAction,
   useDialogIsOpen,
   useThemeMode,
+  useSettings,
+  setSettingsAction,
+  SettingsState,
 } from './state';
 import { Button, Dialog, Header, Main, Slider } from './ui/components';
 import { DarkModeIcon, InfoIcon, LightModeIcon, GearIcon } from './ui/icons';
@@ -34,6 +37,7 @@ const AppRoot = styled.div`
 
 function App(): React.ReactElement | null {
   const mode = useThemeMode();
+  const settings = useSettings();
   const creditsDialogOpen = useDialogIsOpen(DialogKey.CREDITS);
   const settingDialogOpen = useDialogIsOpen(DialogKey.SETTINGS);
 
@@ -48,6 +52,7 @@ function App(): React.ReactElement | null {
      * id and value should probably be the action payload
      */
     const { id, value } = event.target;
+    setSettingsAction({ key: id as keyof SettingsState, value: Number(value) });
   };
 
   React.useEffect(() => {
@@ -98,7 +103,7 @@ function App(): React.ReactElement | null {
             </p>
             <Slider
               color="success"
-              value={4}
+              value={settings.rows}
               min={4}
               max={10}
               id="rows"
@@ -113,7 +118,7 @@ function App(): React.ReactElement | null {
             </p>
             <Slider
               color="success"
-              value={4}
+              value={settings.columns}
               min={4}
               max={10}
               id="columns"
@@ -128,7 +133,7 @@ function App(): React.ReactElement | null {
             </p>
             <Slider
               color="success"
-              value={4}
+              value={settings.shapes}
               min={4}
               max={10}
               id="shapes"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,11 +47,11 @@ const ActionContainer = styled.div`
 
 function App(): React.ReactElement | null {
   const mode = useThemeMode();
-  const { rows, columns, shapes } = useSettings();
+  const gameSettings = useSettings();
   const creditsDialogOpen = useDialogIsOpen(DialogKey.CREDITS);
   const settingDialogOpen = useDialogIsOpen(DialogKey.SETTINGS);
 
-  const [settings, setSettings] = React.useState({ rows, columns, shapes });
+  const [settings, setSettings] = React.useState(gameSettings);
 
   /**
    * Updating the settings object

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   closeDialog,
   openCreditsDialog,
   openSettingsDialog,
-  toggleThemeMode,
+  toggleThemeModeAction,
   useDialogIsOpen,
   useThemeMode,
 } from './state';
@@ -65,7 +65,7 @@ function App(): React.ReactElement | null {
           <Button
             iconOnly
             label="Toggle Light and Dark Mode"
-            onClick={toggleThemeMode}
+            onClick={toggleThemeModeAction}
             icon={mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
           />
           <Button
@@ -121,7 +121,7 @@ function App(): React.ReactElement | null {
             />
           </section>
           <section>
-            <h2>Number of Colors</h2>
+            <h2>Number of Shapes</h2>
             <p>
               Adjust the number of colors in a game.
               <br />A higher value indicates a higher difficulty
@@ -131,7 +131,7 @@ function App(): React.ReactElement | null {
               value={4}
               min={4}
               max={10}
-              id="colors"
+              id="shapes"
               doHandleChange={doHandleSettingChange}
             />
           </section>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,17 @@ const AppRoot = styled.div`
   ${text.md}
 `;
 
+const Section = styled.section`
+  min-width: 20rem;
+  padding: 1rem;
+`;
+
+const ActionContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+`;
+
 function App(): React.ReactElement | null {
   const mode = useThemeMode();
   const { rows, columns, shapes } = useSettings();
@@ -104,11 +115,11 @@ function App(): React.ReactElement | null {
       <Dialog open={settingDialogOpen} onClose={closeDialog}>
         <Dialog.Title>Settings</Dialog.Title>
         <Dialog.Content>
-          <section>
+          <Section>
             <h2>Number of Rows</h2>
             <p>
               Adjust the number of rows in a game.
-              <br />A higher value indicates a higher difficulty
+              <br />A higher value indicates a higher difficulty.
             </p>
             <Slider
               color="success"
@@ -118,12 +129,12 @@ function App(): React.ReactElement | null {
               id="rows"
               doHandleChange={doHandleSettingChange}
             />
-          </section>
-          <section>
+          </Section>
+          <Section>
             <h2>Number of Columns</h2>
             <p>
               Adjust the number of columns in a game.
-              <br />A higher value indicates a higher difficulty
+              <br />A higher value indicates a higher difficulty.
             </p>
             <Slider
               color="success"
@@ -133,12 +144,12 @@ function App(): React.ReactElement | null {
               id="columns"
               doHandleChange={doHandleSettingChange}
             />
-          </section>
-          <section>
+          </Section>
+          <Section>
             <h2>Number of Shapes</h2>
             <p>
               Adjust the number of colors in a game.
-              <br />A higher value indicates a higher difficulty
+              <br />A higher value indicates a higher difficulty.
             </p>
             <Slider
               color="success"
@@ -148,13 +159,15 @@ function App(): React.ReactElement | null {
               id="shapes"
               doHandleChange={doHandleSettingChange}
             />
-          </section>
-          <Button
-            variant="primary"
-            type="submit"
-            label="Save"
-            onClick={doHandleSubmit}
-          />
+          </Section>
+          <ActionContainer>
+            <Button
+              variant="primary"
+              type="submit"
+              label="Save"
+              onClick={doHandleSubmit}
+            />
+          </ActionContainer>
         </Dialog.Content>
       </Dialog>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ import {
   useThemeMode,
   useSettings,
   setSettingsAction,
-  SettingsState,
 } from './state';
 import { Button, Dialog, Header, Main, Slider } from './ui/components';
 import { DarkModeIcon, InfoIcon, LightModeIcon, GearIcon } from './ui/icons';
@@ -37,22 +36,32 @@ const AppRoot = styled.div`
 
 function App(): React.ReactElement | null {
   const mode = useThemeMode();
-  const settings = useSettings();
+  const { rows, columns, shapes } = useSettings();
   const creditsDialogOpen = useDialogIsOpen(DialogKey.CREDITS);
   const settingDialogOpen = useDialogIsOpen(DialogKey.SETTINGS);
 
+  const [settings, setSettings] = React.useState({ rows, columns, shapes });
+
   /**
-   * @todo Create proper dispatch function in actions.ts to update setting state
-   * and initialize slider component with values from state
+   * Updating the settings object
+   * @param event
    */
   const doHandleSettingChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    /**
-     * id and value should probably be the action payload
-     */
     const { id, value } = event.target;
-    setSettingsAction({ key: id as keyof SettingsState, value: Number(value) });
+    setSettings({
+      ...settings,
+      [id]: Number(value),
+    });
+  };
+
+  /**
+   * Function to submit the user's settings to be saved to state
+   */
+  const doHandleSubmit = () => {
+    setSettingsAction(settings);
+    closeDialog();
   };
 
   React.useEffect(() => {
@@ -140,6 +149,12 @@ function App(): React.ReactElement | null {
               doHandleChange={doHandleSettingChange}
             />
           </section>
+          <Button
+            variant="primary"
+            type="submit"
+            label="Save"
+            onClick={doHandleSubmit}
+          />
         </Dialog.Content>
       </Dialog>
 
@@ -149,7 +164,8 @@ function App(): React.ReactElement | null {
         <Dialog.Content>
           <p>
             This React app prototype template was created by&nbsp;
-            <a href="https://github.com/chellimiller">Michelle Miller</a> and&nbsp;
+            <a href="https://github.com/chellimiller">Michelle Miller</a>{' '}
+            and&nbsp;
             <a href="https://github.com/JaredBourget">Jared Bourget</a>.
           </p>
           <p>
@@ -182,8 +198,8 @@ function App(): React.ReactElement | null {
               <li>
                 <a href="https://github.com/sindresorhus/type-fest">
                   Type Fest
-                </a>&nbsp;
-                for utility types.
+                </a>
+                &nbsp; for utility types.
               </li>
               <li>
                 <a href="https://reactrouter.com/en/main">React Router</a> for

--- a/src/state/store/_store.ts
+++ b/src/state/store/_store.ts
@@ -3,8 +3,9 @@ import { persistReducer, persistStore, createTransform } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import { AppState } from './types';
 
-import { default as themeReducer } from './theme.slice'
-import { default as dialogReducer } from './dialog.slice'
+import { default as themeReducer } from './theme.slice';
+import { default as dialogReducer } from './dialog.slice';
+import { default as settingsReducer } from './settings.slice';
 
 const SetTransform = createTransform(
   /**
@@ -24,11 +25,17 @@ const SetTransform = createTransform(
   /** 
    * define which reducers this transform gets called for.
    */
-  { whitelist: ['theme'] }
+  { whitelist: ['theme', 'settings'] }
 );
 
 const themeSliceConfig = {
   key: 'theme',
+  storage,
+  transforms: [SetTransform],
+};
+
+const settingsSliceConfig = {
+  key: 'settings',
   storage,
   transforms: [SetTransform],
 };
@@ -39,6 +46,7 @@ const themeSliceConfig = {
  */
 const persistedReducers = combineReducers({
   theme: persistReducer(themeSliceConfig, themeReducer),
+  settings: persistReducer(settingsSliceConfig, settingsReducer)
 });
 
 const store = configureStore({

--- a/src/state/store/actions.test.ts
+++ b/src/state/store/actions.test.ts
@@ -8,6 +8,7 @@ import {
   resetThemeModeAction,
   setThemeModeAction,
   toggleThemeModeAction,
+  setSettingsAction,
 } from './actions';
 import { DialogKey } from './types';
 
@@ -145,6 +146,26 @@ describe('data/store/actions', () => {
       expect(store.dispatch).toHaveBeenCalledWith({
         type: 'theme/setThemeMode',
         payload: 'light',
+      });
+    });
+  });
+
+  describe('setSettings', () => {
+    it('should dispatch action to set the settings object', () => {
+      // Arrange
+      const SETTINGS = {
+        shapes: 9,
+        rows: 5,
+        columns: 4,
+      };
+
+      // Act
+      setSettingsAction(SETTINGS);
+
+      // Assert
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: 'settings/setSettings',
+        payload: SETTINGS,
       });
     });
   });

--- a/src/state/store/actions.test.ts
+++ b/src/state/store/actions.test.ts
@@ -5,9 +5,9 @@ import {
   openSettingsDialog,
   openRulesDialog,
   openDialog,
-  resetThemeMode,
-  setThemeMode,
-  toggleThemeMode,
+  resetThemeModeAction,
+  setThemeModeAction,
+  toggleThemeModeAction,
 } from './actions';
 import { DialogKey } from './types';
 
@@ -27,7 +27,10 @@ describe('data/store/actions', () => {
       closeDialog();
 
       // Assert
-      expect(store.dispatch).toHaveBeenCalledWith({ type: 'dialog/close' });
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: 'dialog/dialogClose',
+        payload: {},
+      });
     });
   });
 
@@ -44,7 +47,7 @@ describe('data/store/actions', () => {
 
       // Assert
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: 'dialog/open',
+        type: 'dialog/dialogOpen',
         payload: dialog,
       });
     });
@@ -63,7 +66,7 @@ describe('data/store/actions', () => {
 
       // Assert
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: 'dialog/open',
+        type: 'dialog/dialogOpen',
         payload: dialog,
       });
     });
@@ -82,7 +85,7 @@ describe('data/store/actions', () => {
 
       // Assert
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: 'dialog/open',
+        type: 'dialog/dialogOpen',
         payload: dialog,
       });
     });
@@ -101,7 +104,7 @@ describe('data/store/actions', () => {
 
       // Assert
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: 'dialog/open',
+        type: 'dialog/dialogOpen',
         payload: dialog,
       });
     });
@@ -110,11 +113,12 @@ describe('data/store/actions', () => {
   describe('toggleThemeMode', () => {
     it('should dispatch action to toggle light/dark mode', () => {
       // Act
-      toggleThemeMode();
+      toggleThemeModeAction();
 
       // Assert
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: 'theme/mode/toggle',
+        type: 'theme/toggleThemeMode',
+        payload: undefined,
       });
     });
   });
@@ -122,11 +126,12 @@ describe('data/store/actions', () => {
   describe('resetThemeMode', () => {
     it('should dispatch action to reset light/dark mode to user preference', () => {
       // Act
-      resetThemeMode();
+      resetThemeModeAction();
 
       // Assert
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: 'theme/mode/reset',
+        type: 'theme/resetThemeMode',
+        payload: undefined,
       });
     });
   });
@@ -134,11 +139,11 @@ describe('data/store/actions', () => {
   describe('setThemeMode', () => {
     it('should dispatch action to set light/dark mode to provided value', () => {
       // Act
-      setThemeMode('light');
+      setThemeModeAction('light');
 
       // Assert
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: 'theme/mode/set',
+        type: 'theme/setThemeMode',
         payload: 'light',
       });
     });

--- a/src/state/store/actions.ts
+++ b/src/state/store/actions.ts
@@ -1,7 +1,7 @@
 // Actions are bound to the store to avoid Redux-specific concerns outside the module.
 
 import store from './_store';
-import { DialogKey, DialogState, ThemeState, SettingsPayload } from './types';
+import { DialogKey, DialogState, SettingsState, ThemeState } from './types';
 import { setThemeMode, resetThemeMode, toggleThemeMode } from './theme.slice';
 import { dialogOpen, dialogClose } from './dialog.slice';
 import { setSettings } from './settings.slice';
@@ -37,6 +37,6 @@ export function setThemeModeAction(mode: ThemeState['mode']): void {
   store.dispatch(setThemeMode(mode));
 }
 
-export function setSettingsAction({ key, value }: SettingsPayload): void {
-  store.dispatch(setSettings({ key, value }));
+export function setSettingsAction(settings: SettingsState): void {
+  store.dispatch(setSettings(settings));
 }

--- a/src/state/store/actions.ts
+++ b/src/state/store/actions.ts
@@ -1,9 +1,10 @@
 // Actions are bound to the store to avoid Redux-specific concerns outside the module.
 
 import store from './_store';
-import { DialogKey, DialogState, ThemeState } from './types';
+import { DialogKey, DialogState, ThemeState, SettingsPayload } from './types';
 import { setThemeMode, resetThemeMode, toggleThemeMode } from './theme.slice';
 import { dialogOpen, dialogClose } from './dialog.slice';
+import { setSettings } from './settings.slice';
 
 export function closeDialog(): void {
   store.dispatch(dialogClose({}));
@@ -34,4 +35,8 @@ export function resetThemeModeAction(): void {
 
 export function setThemeModeAction(mode: ThemeState['mode']): void {
   store.dispatch(setThemeMode(mode));
+}
+
+export function setSettingsAction({ key, value }: SettingsPayload): void {
+  store.dispatch(setSettings({ key, value }));
 }

--- a/src/state/store/actions.ts
+++ b/src/state/store/actions.ts
@@ -2,44 +2,36 @@
 
 import store from './_store';
 import { DialogKey, DialogState, ThemeState } from './types';
+import { setThemeMode, resetThemeMode, toggleThemeMode } from './theme.slice';
+import { dialogOpen, dialogClose } from './dialog.slice';
 
 export function closeDialog(): void {
-  store.dispatch({ type: 'dialog/close' });
+  store.dispatch(dialogClose({}));
 }
 
 export function openDialog(payload: Exclude<DialogState, null>): void {
-  store.dispatch({ type: 'dialog/open', payload });
+  store.dispatch(dialogOpen(payload));
 }
 
 export function openCreditsDialog(): void {
-  store.dispatch({
-    type: 'dialog/open',
-    payload: { key: DialogKey.CREDITS, data: {} },
-  });
+  store.dispatch(dialogOpen({ key: DialogKey.CREDITS, data: {} }));
 }
 
 export function openSettingsDialog(): void {
-  store.dispatch({
-    type: 'dialog/open',
-    payload: { key: DialogKey.SETTINGS, data: {} },
-  });
+  store.dispatch(dialogOpen({ key: DialogKey.SETTINGS, data: {} }));
 }
-
 export function openRulesDialog(): void {
-  store.dispatch({
-    type: 'dialog/open',
-    payload: { key: DialogKey.RULES, data: {} },
-  });
+  store.dispatch(dialogOpen({ key: DialogKey.RULES, data: {} }));
 }
 
-export function toggleThemeMode(): void {
-  store.dispatch({ type: 'theme/mode/toggle' });
+export function toggleThemeModeAction(): void {
+  store.dispatch(toggleThemeMode());
 }
 
-export function resetThemeMode(): void {
-  store.dispatch({ type: 'theme/mode/reset' });
+export function resetThemeModeAction(): void {
+  store.dispatch(resetThemeMode());
 }
 
-export function setThemeMode(mode: ThemeState['mode']): void {
-  store.dispatch({ type: 'theme/mode/set', payload: mode });
+export function setThemeModeAction(mode: ThemeState['mode']): void {
+  store.dispatch(setThemeMode(mode));
 }

--- a/src/state/store/dialog.slice.test.ts
+++ b/src/state/store/dialog.slice.test.ts
@@ -1,0 +1,60 @@
+import store from './_store';
+import { dialogOpen, dialogClose } from './dialog.slice';
+
+describe('Dialog state tests', () => {
+  it('Should be initialized with state', () => {
+    // Arrange
+    const state = store.getState().dialog;
+
+    // Assert
+    expect(state).toBeNull();
+  });
+
+  it('Should be return dialog data', () => {
+    // Arrange
+    const payload = {
+      key: '123',
+      data: 'foo',
+    };
+    const result = {
+      type: 'dialog/dialogOpen',
+      payload: { key: '123', data: 'foo' },
+    };
+
+    // Act
+    const testResult = store.dispatch(dialogOpen(payload));
+
+    // Assert
+    expect(testResult).toEqual(result);
+  });
+
+  it('Should return state if payload === state', () => {
+    // Arrange
+    const payload = { key: '123', data: 'foo' };
+    const result = {
+      type: 'dialog/dialogOpen',
+      payload: store.getState().dialog,
+    };
+
+    // Act
+    const testResult = store.dispatch(dialogOpen(payload));
+
+    // Assert
+    expect(testResult).toEqual(result);
+  });
+
+  it('Should return null on dialogClose call', () => {
+    // Arrange
+    const payload = null;
+    const result = {
+      type: 'dialog/dialogClose',
+      payload: null,
+    };
+
+    // Act
+    const testResult = store.dispatch(dialogClose(payload));
+
+    // Assert
+    expect(testResult).toEqual(result);
+  });
+});

--- a/src/state/store/dialog.slice.ts
+++ b/src/state/store/dialog.slice.ts
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { isEqual } from 'lodash';
+import { DialogState } from './types';
+
+const INITIAL_STATE: DialogState = null;
+
+export const dialogSlice = createSlice({
+  name: 'dialog',
+  initialState: INITIAL_STATE,
+  reducers: {
+    // @ts-ignore
+    dialogOpen: (state, action: PayloadAction<Exclude<DialogState, null>>) => {
+      if (isEqual(state, action.payload)) return state;
+      return action.payload;
+    },
+    dialogClose: (state) => {
+      return null;
+    },
+  },
+});
+
+export const { dialogOpen, dialogClose } = dialogSlice.actions;
+
+export default dialogSlice.reducer;

--- a/src/state/store/hooks.test.ts
+++ b/src/state/store/hooks.test.ts
@@ -3,8 +3,8 @@ import { useDialogData, useDialogIsOpen, useThemeMode } from './hooks';
 import {
   closeDialog,
   openDialog,
-  setThemeMode,
-  toggleThemeMode,
+  setThemeModeAction,
+  toggleThemeModeAction,
 } from './actions';
 import { DialogKey } from './types';
 
@@ -14,7 +14,7 @@ describe('data/store/hooks', () => {
   describe('useThemeMode', () => {
     it('should return current theme mode', () => {
       // Arrange
-      act(() => setThemeMode('light'));
+      act(() => setThemeModeAction('light'));
 
       // Act
       const { result, rerender } = renderHook(() => useThemeMode());
@@ -23,14 +23,14 @@ describe('data/store/hooks', () => {
       expect(result.current).toBe('light');
 
       // Act
-      act(() => toggleThemeMode());
+      act(() => toggleThemeModeAction());
       rerender();
 
       // Assert
       expect(result.current).toBe('dark');
 
       // Teardown
-      act(() => setThemeMode('light'));
+      act(() => setThemeModeAction('light'));
     });
   });
 

--- a/src/state/store/hooks.test.ts
+++ b/src/state/store/hooks.test.ts
@@ -1,5 +1,10 @@
 import { renderHook, act } from '@testing-library/react';
-import { useDialogData, useDialogIsOpen, useThemeMode } from './hooks';
+import {
+  useDialogData,
+  useDialogIsOpen,
+  useThemeMode,
+  useSettings,
+} from './hooks';
 import {
   closeDialog,
   openDialog,
@@ -31,6 +36,16 @@ describe('data/store/hooks', () => {
 
       // Teardown
       act(() => setThemeModeAction('light'));
+    });
+  });
+
+  describe('useSettings', () => {
+    it('should return the settings', () => {
+      // Act
+      const { result } = renderHook(() => useSettings());
+
+      // Assert
+      expect(result.current.shapes).toBe(4);
     });
   });
 

--- a/src/state/store/hooks.ts
+++ b/src/state/store/hooks.ts
@@ -27,12 +27,21 @@ function useSelector<T>(
 
 const selectThemeMode = (state: AppState) => state.persistedReducers.theme.mode;
 
+const selectSettings = (state: AppState) => state.persistedReducers.settings;
+
 /**
  * Returns the color scheme for the current theme.
  *
  * @returns 'light' or 'dark'
  */
 export const useThemeMode = () => useSelector(selectThemeMode);
+
+/**
+ * Returns the currents settings.
+ *
+ * @returns the settings object
+ */
+export const useSettings = () => useSelector(selectSettings);
 
 const selectDialogData = (state: AppState, key: string) =>
   state.dialog?.key === key ? state.dialog.data : null;

--- a/src/state/store/hooks.ts
+++ b/src/state/store/hooks.ts
@@ -27,7 +27,10 @@ function useSelector<T>(
 
 const selectThemeMode = (state: AppState) => state.persistedReducers.theme.mode;
 
-const selectSettings = (state: AppState) => state.persistedReducers.settings;
+/**
+ * Removing the _persist key from persisted settings state
+ */
+const selectSettings = (state: AppState) => (({ _persist: _, ...rest }) => rest)(state.persistedReducers.settings);
 
 /**
  * Returns the color scheme for the current theme.

--- a/src/state/store/hooks.ts
+++ b/src/state/store/hooks.ts
@@ -25,7 +25,7 @@ function useSelector<T>(
   return value;
 }
 
-const selectThemeMode = (state: AppState) => state.theme.mode;
+const selectThemeMode = (state: AppState) => state.persistedReducers.theme.mode;
 
 /**
  * Returns the color scheme for the current theme.

--- a/src/state/store/settings.slice.test.ts
+++ b/src/state/store/settings.slice.test.ts
@@ -1,5 +1,5 @@
 import store from './_store';
-import { setSettings, resetSettings } from './settings.slice';
+import reducer, { setSettings, resetSettings } from './settings.slice';
 
 const INITIAL_STATE = {
   rows: 8,
@@ -11,8 +11,44 @@ describe('Settings state tests', () => {
   it('Should be initialized with a state', () => {
     // Act
     const state = store.getState().persistedReducers;
+    const stateClone = (({ _persist: _, ...rest }) => rest)(state.settings);
 
     // Assert
-    expect(state.settings.rows).toEqual(8);
+    expect(stateClone).toEqual(INITIAL_STATE);
+  });
+
+  /**
+   * Redux-persist seems to interfere with testing store updates
+   */
+  // it('Should be set settings', () => {
+  //   // Arrange
+  //   const NEW_STATE = {
+  //     rows: 10,
+  //     columns: 5,
+  //     shapes: 4,
+  //   };
+
+  //   // Assert
+  //   expect(reducer(INITIAL_STATE, setSettings(NEW_STATE))).toEqual({
+  //     ...NEW_STATE,
+  //   });
+  // });
+
+  it('Should reset state', () => {
+    // Arrange
+    const NEW_STATE = {
+      rows: 10,
+      columns: 5,
+      shapes: 4,
+    };
+
+    // Act
+    store.dispatch(setSettings(NEW_STATE));
+    store.dispatch(resetSettings());
+    const state = store.getState().persistedReducers;
+    const stateClone = (({ _persist: _, ...rest }) => rest)(state.settings);
+
+    // Assert
+    expect(stateClone).toEqual(INITIAL_STATE);
   });
 });

--- a/src/state/store/settings.slice.test.ts
+++ b/src/state/store/settings.slice.test.ts
@@ -1,0 +1,18 @@
+import store from './_store';
+import { setSettings, resetSettings } from './settings.slice';
+
+const INITIAL_STATE = {
+  rows: 8,
+  columns: 4,
+  shapes: 4,
+};
+
+describe('Settings state tests', () => {
+  it('Should be initialized with a state', () => {
+    // Act
+    const state = store.getState().persistedReducers;
+
+    // Assert
+    expect(state.settings.rows).toEqual(8);
+  });
+});

--- a/src/state/store/settings.slice.ts
+++ b/src/state/store/settings.slice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { SettingsState, SettingsPayload } from './types';
+
+const INITIAL_STATE: SettingsState = {
+  rows: 8,
+  columns: 4,
+  shapes: 4,
+};
+
+export const settingsSlice = createSlice({
+  name: 'settings',
+  initialState: { ...INITIAL_STATE },
+  reducers: {
+    setSettings: (state, action: PayloadAction<SettingsPayload>) => {
+      const { key, value } = action.payload;
+      state[key] = value;
+    },
+
+    resetSettings: (state) => {
+      state = { ...INITIAL_STATE };
+    },
+  },
+});
+
+export const { setSettings, resetSettings } = settingsSlice.actions;
+
+export default settingsSlice.reducer;

--- a/src/state/store/settings.slice.ts
+++ b/src/state/store/settings.slice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { SettingsState, SettingsPayload } from './types';
+import { SettingsState } from './types';
 
 const INITIAL_STATE: SettingsState = {
   rows: 8,
@@ -11,9 +11,9 @@ export const settingsSlice = createSlice({
   name: 'settings',
   initialState: { ...INITIAL_STATE },
   reducers: {
-    setSettings: (state, action: PayloadAction<SettingsPayload>) => {
-      const { key, value } = action.payload;
-      state[key] = value;
+    setSettings: (state, action: PayloadAction<SettingsState>) => {
+      const settings = action.payload;
+      state = settings;
     },
 
     resetSettings: (state) => {

--- a/src/state/store/theme.slice.test.ts
+++ b/src/state/store/theme.slice.test.ts
@@ -1,0 +1,45 @@
+import store from './_store';
+import { setThemeMode, resetThemeMode, toggleThemeMode } from './theme.slice';
+
+describe('Theme state tests', () => {
+  it('Should be initialized with user`s preference', () => {
+    // Act
+    const state = store.getState().persistedReducers.theme;
+
+    // Assert
+    expect(state.mode).toEqual('dark');
+  });
+
+  it('Should change theme mode in state', () => {
+    // Act
+    store.dispatch(setThemeMode('light'));
+    const state = store.getState().persistedReducers.theme;
+
+    // Assert
+    expect(state.mode).toEqual('light');
+  });
+
+  it('Should reset theme to window theme mode', () => {
+    // Arrange
+    store.dispatch(setThemeMode('light'));
+
+    // Act
+    store.dispatch(resetThemeMode());
+    const state = store.getState().persistedReducers.theme;
+
+    // Assert
+    expect(state.mode).toEqual('dark');
+  });
+
+  it('Should toggle theme mode', () => {
+    // Arrange
+    store.dispatch(setThemeMode('light'));
+
+    // Act
+    store.dispatch(toggleThemeMode());
+    const state = store.getState().persistedReducers.theme;
+
+    // Assert
+    expect(state.mode).toEqual('dark');
+  });
+});

--- a/src/state/store/theme.slice.ts
+++ b/src/state/store/theme.slice.ts
@@ -1,0 +1,37 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { ThemeState } from './types';
+
+const isDarkMode = () => {
+  return (
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+};
+
+const initialThemeState: ThemeState = {
+  mode: isDarkMode() ? 'dark' : 'light',
+};
+
+/**
+ * function to create an initial state and the asscociated reducers
+ */
+export const themeSlice = createSlice({
+  name: 'theme',
+  initialState: { ...initialThemeState },
+  reducers: {
+    setThemeMode: (state, action: PayloadAction<'light' | 'dark'>) => {
+      state.mode = action.payload;
+    },
+    resetThemeMode: (state) => {
+      state.mode = initialThemeState.mode;
+    },
+    toggleThemeMode: (state) => {
+      state.mode = state.mode === 'dark' ? 'light' : 'dark';
+    },
+  },
+});
+
+export const { setThemeMode, resetThemeMode, toggleThemeMode } =
+  themeSlice.actions;
+
+export default themeSlice.reducer;

--- a/src/state/store/types.ts
+++ b/src/state/store/types.ts
@@ -27,6 +27,7 @@ export type SettingsState  = {
   rows: number;
   columns: number;
   shapes: number;
+  _persist?: any;
 }
 
 export type ThemeAction =

--- a/src/state/store/types.ts
+++ b/src/state/store/types.ts
@@ -23,13 +23,11 @@ export interface ThemeState {
   mode: 'light' | 'dark';
 }
 
-export interface SettingsState {
+export type SettingsState  = {
   rows: number;
   columns: number;
   shapes: number;
 }
-
-export type SettingsPayload = { key: keyof SettingsState; value: number };
 
 export type ThemeAction =
   | Action<'theme/mode/toggle'>

--- a/src/state/store/types.ts
+++ b/src/state/store/types.ts
@@ -11,7 +11,9 @@ export enum DialogKey {
 type BaseDialogState<K extends DialogKey, D = unknown> = { key: K; data: D };
 
 // This could be modified to be a union type for stricter type validation.
-export type DialogState = null | BaseDialogState<DialogKey.CREDITS | DialogKey.RULES | DialogKey.SETTINGS>;
+export type DialogState = null | BaseDialogState<
+  DialogKey.CREDITS | DialogKey.RULES | DialogKey.SETTINGS
+>;
 
 export type DialogAction =
   | Action<'dialog/close'>
@@ -19,13 +21,15 @@ export type DialogAction =
 
 export interface ThemeState {
   mode: 'light' | 'dark';
-};
+}
 
 export interface SettingsState {
   rows: number;
   columns: number;
   shapes: number;
-};
+}
+
+export type SettingsPayload = { key: keyof SettingsState; value: number };
 
 export type ThemeAction =
   | Action<'theme/mode/toggle'>
@@ -35,7 +39,8 @@ export type ThemeAction =
 export type AppState = {
   persistedReducers: {
     theme: ThemeState;
-  }
+    settings: SettingsState;
+  };
   dialog: DialogState;
 };
 

--- a/src/state/store/types.ts
+++ b/src/state/store/types.ts
@@ -19,7 +19,13 @@ export type DialogAction =
 
 export interface ThemeState {
   mode: 'light' | 'dark';
-}
+};
+
+export interface SettingsState {
+  rows: number;
+  columns: number;
+  shapes: number;
+};
 
 export type ThemeAction =
   | Action<'theme/mode/toggle'>
@@ -27,7 +33,9 @@ export type ThemeAction =
   | PayloadAction<ThemeState['mode'], 'theme/mode/set'>;
 
 export type AppState = {
-  theme: ThemeState;
+  persistedReducers: {
+    theme: ThemeState;
+  }
   dialog: DialogState;
 };
 

--- a/src/ui/emotion/slider.ts
+++ b/src/ui/emotion/slider.ts
@@ -21,6 +21,7 @@ const slider: SliderStyles = {
     background: grey;
     border-radius: 5px;
     background-repeat: no-repeat;
+    width: calc(100% - 3rem);
 
     &::-webkit-slider-thumb {
       -webkit-appearance: none;

--- a/testsetup.ts
+++ b/testsetup.ts
@@ -1,0 +1,13 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: query.includes('(prefers-color-scheme: dark)'),
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
## Description
This MR adds the `theme.slice.ts` and `dialog.slice.ts` files from the template project and includes a `settings.slice.ts` file

## Changes
- A settings slice has been added and is persisted in `localStorage` in the form of
```js
{
     ...persistedState,
     settings: {
          rows: 8,
          columns: 4,
          shapes: 4,
     },
}
```
- The settings dialog has been connected with the persisted settings state

## TODO
- [x] Add tests for `setting.slice.ts`
- [x] Add action tests
- [x] Add hook tests